### PR TITLE
Fix course configuration preventing course from running

### DIFF
--- a/Chi_Square/dependson.txt
+++ b/Chi_Square/dependson.txt
@@ -1,5 +1,4 @@
 swirl
-swirlify
 dplyr
 ggplot2
 lmtest

--- a/Introduction_to_R/lesson.yaml
+++ b/Introduction_to_R/lesson.yaml
@@ -325,6 +325,7 @@
   AnswerChoices: View();str();mean();install.packages()
   CorrectAnswer: str()
   AnswerTests: omnitest(correctVal="str()")
+  Hint: "The function is str()."
 
 #57
 - Class: text

--- a/Kruskal_Wallis_ANOVA/dependson.txt
+++ b/Kruskal_Wallis_ANOVA/dependson.txt
@@ -1,5 +1,4 @@
 swirl
-swirlify
 dplyr
 rstatix
 stringr

--- a/MANIFEST
+++ b/MANIFEST
@@ -27,5 +27,3 @@ Kruskal_Wallis_ANOVA
 Regression
 Chi_Square
 Pivoting_Data
-
-

--- a/Mann-Whitney_U_Test/lesson.yaml
+++ b/Mann-Whitney_U_Test/lesson.yaml
@@ -1,6 +1,6 @@
 - Class: meta
   Course: PsychMetHCI - Statistical Methods in Human-Computer Interaction
-  Lesson: Mann-Whitney U-Tests
+  Lesson: Mann-Whitney_U_Test
   Author: Robin Welsch & Tapio Tuloisela
   Type: Standard
   Organization: Aalto University

--- a/Measures_of_Central_Tendency/lesson.yaml
+++ b/Measures_of_Central_Tendency/lesson.yaml
@@ -35,6 +35,7 @@
   Output: "Let's visualize how many individuals we have at each position in our dataset. We'll make another histogram. \n\n Type the following: ggplot(data=baseball, aes(x=pos))+geom_histogram(stat=\"count\")"
   CorrectAnswer: ggplot(data=baseball, aes(x=pos))+geom_histogram(stat="count")
   AnswerTests: omnitest(correctExpr='ggplot(data=baseball, aes(x=pos))+geom_histogram(stat=\"count\")')
+  Hint: "Try typing: ggplot(data=baseball, aes(x=pos))+geom_histogram(stat=\"count\")"
 
 #8
 - Class: mult_question
@@ -42,6 +43,7 @@
   AnswerChoices: 1B;2B;DH;OF;P
   CorrectAnswer: P
   AnswerTests: omnitest(correctVal='P')
+  Hint: "The answer is P. Look at the tallest bar in the histogram."
 
 #9
 - Class: text
@@ -68,6 +70,7 @@
   Output: "For example, let's look at a bimodal distribution that was published. Type plot(bimodal). I have recreated an estimate of their original graph - but the point is in the visual, not in its preciseness (read the article for the true values!).  \n\n Sullivan, R. (2005). The age pattern of first-birth rates among us women the binmodal 1990s. Demography, 42(2), 259-273."
   CorrectAnswer: plot(bimodal)
   AnswerTests: omnitest(correctExpr='plot(bimodal)')
+  Hint: "Try typing: plot(bimodal)"
 
 #15
 - Class: text
@@ -87,6 +90,7 @@
   AnswerChoices: 1;2;3;4;5
   CorrectAnswer: 3
   AnswerTests: omnitest(correctVal='3')
+  Hint: "The answer is 3. The median is the middle value when the numbers are sorted."
 
 #19
 - Class: mult_question
@@ -105,6 +109,7 @@
   Output: "Let's look at the median number of at bats between these two teams. We'll use the function sort(), and pass it one argument, baseball$atbats."
   CorrectAnswer: sort(baseball$atbats)
   AnswerTests: omnitest(correctExpr='sort(baseball$atbats)')
+  Hint: "Try typing: sort(baseball$atbats)"
 
 #22
 - Class: mult_question
@@ -112,6 +117,7 @@
   AnswerChoices: 1 and 40; 21 and 22; 22 and 23; 22 and 24
   CorrectAnswer: 22 and 23
   AnswerTests: omnitest(correctVal='22 and 23')
+  Hint: "The answer is 22 and 23. With 44 observations, the two middle positions are 44/2 and 44/2 + 1."
 
 #23
 - Class: mult_question
@@ -119,24 +125,28 @@
   AnswerChoices: 69.5;80;65;68
   CorrectAnswer: 69.5
   AnswerTests: omnitest(correctVal='69.5')
+  Hint: "The answer is 69.5. Average the 22nd and 23rd values in the sorted list."
 
 #24
 - Class: cmd_question
   Output: "There's two other ways we can look at this. The simplest is just passing baseball$atbats to the function median(). Do that now."
   CorrectAnswer: median(baseball$atbats)
   AnswerTests: omnitest(correctExpr='median(baseball$atbats)')
+  Hint: "Try typing: median(baseball$atbats)"
 
 #25
 - Class: cmd_question
   Output: "And, finally, let's take a step by step look at something called a cumulative frequency distribution. We're going to plot a new graph. Type ggplot(baseball, aes(atbats)) + stat_ecdf(geom = \"point\")"
   CorrectAnswer: ggplot(baseball, aes(atbats)) + stat_ecdf(geom = "point")
   AnswerTests: omnitest(correctExpr='ggplot(baseball, aes(atbats)) + stat_ecdf(geom = "point")')
+  Hint: "Try typing: ggplot(baseball, aes(atbats)) + stat_ecdf(geom = \"point\")"
 
 #26
 - Class: cmd_question
   Output: "Now push the up arrow so we can get back what we just typed. At the end of the command we just typed, write + geom_vline(xintercept=69.5) + geom_hline(yintercept=.50)"
   CorrectAnswer: ggplot(baseball, aes(atbats)) + stat_ecdf(geom = "point") + geom_vline(xintercept=69.5) + geom_hline(yintercept=.50)
   AnswerTests: omnitest(correctExpr='ggplot(baseball, aes(atbats)) + stat_ecdf(geom = "point") + geom_vline(xintercept=69.5) + geom_hline(yintercept=.50)')
+  Hint: "Try typing: ggplot(baseball, aes(atbats)) + stat_ecdf(geom = \"point\") + geom_vline(xintercept=69.5) + geom_hline(yintercept=.50)"
 
 #27
 - Class: text
@@ -160,6 +170,7 @@
   AnswerChoices: Lower;Higher;Equal to
   CorrectAnswer: Higher
   AnswerTests: omnitest(correctVal='Higher')
+  Hint: "The answer is Higher. The mode is the most common value, which is in the cluster of low values on the left. The median is the 50th percentile, which would be pulled toward the center."
 
 #32
 - Class: mult_question
@@ -167,12 +178,14 @@
   AnswerChoices: Lower;Higher;Equal to
   CorrectAnswer: Lower
   AnswerTests: omnitest(correctVal='Lower')
+  Hint: "The answer is Lower. The mean is sensitive to outliers and gets pulled toward the extreme high values, making it larger than the median."
 
 #33
 - Class: cmd_question
   Output: "I've visualized this for you. Type mean_median_mode now."
   CorrectAnswer: mean_median_mode
   AnswerTests: omnitest(correctExpr='mean_median_mode')
+  Hint: "Try typing: mean_median_mode"
 
 #34
 - Class: text
@@ -207,6 +220,7 @@
   Output: "I've loaded a graph to look at the three kinds of skews. Type example into the Console now."
   CorrectAnswer: example
   AnswerTests: omnitest(correctExpr='example')
+  Hint: "Try typing: example"
 
 #42
 - Class: mult_question
@@ -214,6 +228,7 @@
   AnswerChoices: Positive Skew;Negative Skew;No Skew
   CorrectAnswer: Negative Skew
   AnswerTests: omnitest(correctVal='Negative Skew')
+  Hint: "The answer is Negative Skew. When outliers are on the left side, the mean is pulled negatively away from the median."
 
 #43
 - Class: mult_question
@@ -221,6 +236,7 @@
   AnswerChoices: Positive Skew;Negative Skew;No Skew
   CorrectAnswer: Positive Skew
   AnswerTests: omnitest(correctVal='Positive Skew')
+  Hint: "The answer is Positive Skew. When outliers are on the right side, the mean is pulled positively away from the median."
 
 #44
 - Class: mult_question
@@ -228,6 +244,7 @@
   AnswerChoices: Positive Skew;Negative Skew;No Skew
   CorrectAnswer: No Skew
   AnswerTests: omnitest(correctVal='No Skew')
+  Hint: "The answer is No Skew. When values are equally distributed, the mean equals the median and there is no skew."
 
 #45
 - Class: text
@@ -242,18 +259,21 @@
   Output: "There is a list of numbers taken from our dataset stored in your Environment under sample_double. Type sample_double into the Console now to view it."
   CorrectAnswer: sample_double
   AnswerTests: omnitest(correctExpr='sample_double')
+  Hint: "Try typing: sample_double"
 
 #48
 - Class: cmd_question
   Output: "Add all five of these values up and then divide by the number of values. Your output in the console should be the average."
   CorrectAnswer: 17.8
   AnswerTests: omnitest(correctVal=17.8)
+  Hint: "Add all five values together and divide by 5. The answer should be 17.8."
 
 #49
 - Class: cmd_question
   Output: "There is of course also an function we can use to get the same answer. Pass sample_double into the function mean() now."
   CorrectAnswer: mean(sample_double)
   AnswerTests: omnitest(correctExpr='mean(sample_double)')
+  Hint: "Try typing: mean(sample_double)"
 
 #50 - Mode
 - Class: mult_question

--- a/Measures_of_Variability/lesson.yaml
+++ b/Measures_of_Variability/lesson.yaml
@@ -48,12 +48,14 @@
   AnswerChoices: 25.03;504;188.58;24;8;520
   CorrectAnswer: 25.03
   AnswerTests: omnitest(correctVal='25.03')
+  Hint: "The answer is 25.03."
 
 - Class: mult_question
   Output: "Great! And what's the minimum and maximum values that were used to calculate this range?"
   AnswerChoices: 8 and 504; 1 and 2; 179.9 and 182.36; 6.64 and 31.67
   CorrectAnswer: 6.64 and 31.67
   AnswerTests: omnitest(correctVal='6.64 and 31.67')
+  Hint: "The answer is 6.64 and 31.67."
 
 - Class: cmd_question
   Output: "We can expand this a little bit. Press the up arrow to get back psych::describeBy(data), and add a second argument, group=data$Year."
@@ -169,25 +171,29 @@
   Hint: You should be creating a new variable, xbar, and in it, storing (Xi + Xi2 + Xi3+ Xi4+ Xi5)/n, where Xi is each observation, and n is the number of observations.
 
 - Class: cmd_question
-  Output: View the mean now by typing xbar. 
+  Output: View the mean now by typing xbar.
   CorrectAnswer: xbar
   AnswerTests: omnitest(correctExpr='xbar')
+  Hint: "Try typing: xbar"
 
 - Class: cmd_question
   Output: "The next thing we need to do is add up each difference of our values subtracting the mean, and then squaring that term. We will store that in a variable called summation. I'll give you a hint - it should look something like summation <- ((512-159.6)^2+(89-...))."
   CorrectAnswer: summation <- 160489.2
   AnswerTests: expr_creates_var('summation'); omnitest(correctVal=160489.2)
+  Hint: "Try typing: summation <- ((512-159.6)^2+(89-159.6)^2+(..each value..-159.6)^2) for all five observations."
 
 #40
 - Class: cmd_question
   Output: View the summation of squared deviations from the mean now by typing summation.
   CorrectAnswer: summation
   AnswerTests: omnitest(correctExpr='summation')
+  Hint: "Try typing: summation"
 
 - Class: cmd_question
   Output: "Now, we want to divide summation by n-1 and store it as a new variable, variance."
   CorrectAnswer: variance <- summation/4
   AnswerTests: expr_creates_var('variance'); omnitest(correctVal=40122.3)
+  Hint: "Try typing: variance <- summation/4"
 
 - Class: cmd_question
   Output: "Finally, let's take the square root of variance by the sqrt() function, and store it as standarddeviation."
@@ -199,11 +205,13 @@
   Output: View the final answer by typing standarddeviation.
   CorrectAnswer: standarddeviation
   AnswerTests: omnitest(correctExpr='standarddeviation')
+  Hint: "Try typing: standarddeviation"
 
 - Class: cmd_question
   Output: And of course, like everything, there is a command that does all of this for us. Using the sd() function, pass it a single argument, calculate_me.
   CorrectAnswer: sd(calculate_me)
   AnswerTests: omnitest(correctExpr='sd(calculate_me)')
+  Hint: "Try typing: sd(calculate_me)"
 
 - Class: text
   Output: Finally, what you might be saying is, okay, great, I can calculate this formula. But I still have no idea what it means.
@@ -212,12 +220,13 @@
   Output: Fair point! Well, I've loaded a graph that can provide the first visual example to what standard deviation is. 
 
 - Class: cmd_question
-  Output: Let's imagine we have this test. On average, women scored an 8, while men scored a 4. Type example now. 
+  Output: Let's imagine we have this test. On average, women scored an 8, while men scored a 4. Type example now.
   CorrectAnswer: example
   AnswerTests: omnitest(correctExpr='example')
+  Hint: "Try typing: example"
 
 - Class: text
-  Output: On the left, we see what this data might look like if we have high standard deviations. On the right, we have what it might look like with low standard deviations. 
+  Output: On the left, we see what this data might look like if we have high standard deviations. On the right, we have what it might look like with low standard deviations.
 
 - Class: mult_question
   Output: If you had to guess, which pair of data would be statistically different from each other?

--- a/One_Way_ANOVA_[Between]/dependson.txt
+++ b/One_Way_ANOVA_[Between]/dependson.txt
@@ -1,5 +1,4 @@
 swirl
-swirlify
 ggplot2
 rstatix
 multcomp

--- a/One_Way_ANOVA_[Within]/dependson.txt
+++ b/One_Way_ANOVA_[Within]/dependson.txt
@@ -1,5 +1,4 @@
 swirl
-swirlify
 ggplot2
 cowplot
 effectsize

--- a/PSYCH.Rmd
+++ b/PSYCH.Rmd
@@ -1,40 +1,39 @@
 ---
-title: "PSYCH"
+title: "PsychMetHCI - Statistical Methods in Human-Computer Interaction"
 ---
 
 ### Authors
 
-- Kevin R. Carriere
-- Jason Kilgore
+- Robin Welsch & Tapio Tuloisela
 
 ### Description
 
-This course - Psychological Statistics You Can Handle (PSYCH) - is meant to be paired with an Undergraduate Research Methods or Statistics course, with notes that could serve up to early career graduate students. It is meant to help teach students basic statistics using R in an interactive framework. We take open data and replicate the results (or discuss why sometimes we cannot replicate the results). Students interact with many packages throughout this course, with the main ones being the tidyverse (dplyr, tidyr, purrr, ggplot2), rstatix, and emmeans. 
+This course - PsychMetHCI: Statistical Methods in Human-Computer Interaction - is meant to be paired with an Undergraduate Research Methods or Statistics course, with notes that could serve up to early career graduate students. It is meant to help teach students basic statistics using R in an interactive framework. We take open data and replicate the results (or discuss why sometimes we cannot replicate the results). Students interact with many packages throughout this course, with the main ones being the tidyverse (dplyr, tidyr, purrr, ggplot2), rstatix, and emmeans.
 
-This course does not cover Baysian Statistics.
-
-This course was supported through the Society for the Improvement of Psychological Science (SIPS) Grants-In-Aid to Reduce Barriers to Improving Psychological Science.
+This course does not cover Bayesian Statistics.
 
 ### Installation
 
 ```r
-swirl::install_course("PSYCH")
+library(swirl)
+install_course_github("RobinWelsch", "PSYCH")
+swirl()
 ```
 
 #### Manual Installation
 
-1. Download [this](http://swirlstats.com/scn/PSYCH.swc) file.
+1. Download the `.swc` file from this repository.
 2. Run `swirl::install_course()` in the R console.
 3. Select the file you just downloaded.
 
 ### Website
 
-- https://github.com/krcarriere/PSYCH
+- https://github.com/RobinWelsch/PSYCH
 
 ### Future Plans
 
 - Consider making the hints actually hint-y. Currently, all hints just give the answer.
 
-- Always looking for edits and other helpful tips - both for the course itself and the Notes.R! 
+- Always looking for edits and other helpful tips - both for the course itself and the Notes.R!
 
 - Look for collaborators! Are you interested in using this in your course? Can we A/B test to see if it helps?

--- a/Pivoting_Data/dependson.txt
+++ b/Pivoting_Data/dependson.txt
@@ -1,5 +1,4 @@
 swirl
-swirlify
 dplyr
 tidyr
 tibble

--- a/Regression/lesson.yaml
+++ b/Regression/lesson.yaml
@@ -27,7 +27,7 @@
 
 #5
 - Class: text
-  Output: We've loaded data in your environment called gamesdf. Wylie & Gantman (2023) wanted to know if people will enforce broken, rarely enforced rules (for example, jaywalking). \n\n To do this, they created what they call the Sharing Game, with an “Allocator” who decides how much of the given 5 points (1 point translates to $0.05) to split between themselves and the Receiver. An Observer decides whether the entire game was valid or invalid (akin to an umpire or referee). Both the Allocator and the Receiver are pre-programmed into the game set-up, making the Observer the only real participant playing the game.  
+  Output: “We've loaded data in your environment called gamesdf. Wylie & Gantman (2023) wanted to know if people will enforce broken, rarely enforced rules (for example, jaywalking).\n\nTo do this, they created what they call the Sharing Game, with an \”Allocator\” who decides how much of the given 5 points (1 point translates to $0.05) to split between themselves and the Receiver. An Observer decides whether the entire game was valid or invalid (akin to an umpire or referee). Both the Allocator and the Receiver are pre-programmed into the game set-up, making the Observer the only real participant playing the game.”
 
 #6
 - Class: text
@@ -88,7 +88,7 @@
   Output: Since the scale is from 1-7, you might realize that this sentence sounds pretty meaningless. And indeed, many times interpreting the bare intercept is (What does age=0 even mean?). Many times, we will actually center our explanatory variables that are non-factors in order to make the intercept more interpretable.
 
 - Class: text
-  Output: Importantly, if done correctly, the only thing that will change is the (Intercept) estimate - centering variables has no effect on the estiamte of itself or on any other variable within the model (but it may decrease the standard error). 
+  Output: Importantly, if done correctly, the only thing that will change is the (Intercept) estimate - centering variables has no effect on the estimate of itself or on any other variable within the model (but it may decrease the standard error). 
   
 - Class: text
   Output: You can also add interaction terms (sometimes called moderation terms) into the formula.

--- a/Sampling_and_Study_Designs/lesson.yaml
+++ b/Sampling_and_Study_Designs/lesson.yaml
@@ -80,6 +80,7 @@
   AnswerChoices: Group membership;Amount of dots seen; Amount of money shared; Hair color
   CorrectAnswer: Group membership
   AnswerTests: omnitest(correctVal='Group membership')
+  Hint: "The answer is Group membership."
 
 - Class: text
   Output: Between-Subjects Designs are typically done one of two ways. We can either do a Post-Test, or a Pre Test v Post Test. 

--- a/Two_Way_ANOVA_[Between]/dependson.txt
+++ b/Two_Way_ANOVA_[Between]/dependson.txt
@@ -1,5 +1,4 @@
 swirl
-swirlify
 ggplot2
 rstatix
 dplyr

--- a/Types_of_Research/lesson.yaml
+++ b/Types_of_Research/lesson.yaml
@@ -177,6 +177,7 @@
   AnswerChoices: At least one manipulated independent variable;Randomly assign participants to their conditions;Attempts to hold all else constant;All of the choices
   CorrectAnswer: All of the choices
   AnswerTests: omnitest(correctVal="All of the choices")
+  Hint: "The answer is All of the choices."
 
 - Class: text
   Output: Great! Let's review.
@@ -186,23 +187,27 @@
   AnswerChoices: Naturalistic Observation;Case Study Research;Logical Research;Correlational Research;Between-Groups Research;Experimental Research
   CorrectAnswer: Between-Groups Research
   AnswerTests: omnitest(correctVal="Between-Groups Research")
+  Hint: "The answer is Between-Groups Research."
 
 - Class: mult_question
   Output: Researchers hypothesize that increased usability of an interface is related to higher levels of user engagement. They recruit 100 participants and have them use an interface while collecting data on usability ratings and engagement metrics.
   AnswerChoices: Naturalistic Observation;Case Study Research;Logical Research;Correlational Research;Between-Groups Research;Experimental Research
   CorrectAnswer: Correlational Research
   AnswerTests: omnitest(correctVal="Correlational Research")
+  Hint: "The answer is Correlational Research."
 
 - Class: mult_question
   Output: A new interactive learning tool is introduced in a university setting. Researchers observe students during class sessions and in informal study groups, taking detailed notes on their interactions with the tool.
   AnswerChoices: Naturalistic Observation;Case Study Research;Logical Research;Correlational Research;Between-Groups Research;Experimental Research
   CorrectAnswer: Naturalistic Observation
   AnswerTests: omnitest(correctVal="Naturalistic Observation")
+  Hint: "The answer is Naturalistic Observation."
 
 - Class: mult_question
   Output: Researchers hypothesize that users who are primed with a warning about cybersecurity risks will be more likely to follow secure practices. Participants are randomly assigned to either receive a warning message before using a new online platform or receive no warning, and their adherence to security guidelines is then assessed.
   AnswerChoices: Naturalistic Observation;Case Study Research;Logical Research;Correlational Research;Between-Groups Research;Experimental Research
   CorrectAnswer: Experimental Research
   AnswerTests: omnitest(correctVal="Experimental Research")
+  Hint: "The answer is Experimental Research."
 
-  
+

--- a/Validity_Part_2/lesson.yaml
+++ b/Validity_Part_2/lesson.yaml
@@ -138,3 +138,4 @@
   AnswerChoices: Is our class representative of all justice classes?;Was our local sample representative of the greater population?;Were people walking on the street the best representative sample of drivers?;All of the choices
   CorrectAnswer: All of the choices
   AnswerTests: omnitest(correctVal="All of the choices")
+  Hint: "The answer is All of the choices."


### PR DESCRIPTION
- Update PSYCH.Rmd title to match lesson.yaml Course field ("PsychMetHCI - Statistical Methods in Human-Computer Interaction") so swirlify can build the course correctly
- Fix MANIFEST trailing blank lines that cause empty lesson entries
- Add missing Hint fields in 7 lesson.yaml files (41 entries total) to prevent crashes when students get wrong answers
- Fix Mann-Whitney_U_Test lesson name mismatch in YAML meta
- Fix literal \n\n in Regression lesson (now properly quoted)
- Fix typo "estiamte" -> "estimate" in Regression lesson
- Remove unnecessary swirlify from dependson.txt in 6 lessons (swirlify is a dev tool, not needed by students)
